### PR TITLE
Replace software accumulator clock with hardware output-compare

### DIFF
--- a/fw/src/input.rs
+++ b/fw/src/input.rs
@@ -1,8 +1,6 @@
-use core::sync::atomic::Ordering;
-
 use crate::sequencer::{
-    mark_dirty, select_step, set_step, DIRTY_NOTE_DATA, DIRTY_PATTERN, DIRTY_RT_CACHE, PLAYING,
-    SequencerState,
+    mark_dirty, select_step, set_step, toggle_playback, DIRTY_NOTE_DATA,
+    DIRTY_PATTERN, DIRTY_RT_CACHE, SequencerState,
 };
 use crate::utils::iter_bits_u8;
 use rtt_target::rprintln;
@@ -44,11 +42,10 @@ pub fn handle_button_press(button: Button, sequencer_state: &mut SequencerState)
             rprintln!("Selected pattern {}", n);
         }
         Button::Play => {
-            let was_playing = PLAYING.fetch_xor(true, Ordering::Relaxed);
-            rprintln!("{}", if was_playing { "Pause" } else { "Play" });
+            let playing = toggle_playback();
+            rprintln!("{}", if playing { "Play" } else { "Pause" });
         }
         Button::Stop => {
-            PLAYING.store(false, Ordering::Relaxed);
             rprintln!("Stop");
         }
         Button::Note(n) => {

--- a/fw/src/main.rs
+++ b/fw/src/main.rs
@@ -25,6 +25,8 @@ use curse::input::{handle_button_press, key_to_button};
 
 #[cfg(feature = "perf")]
 use curse::perf::{init_cycle_counter, measure_cycles};
+#[cfg(feature = "perf")]
+use curse::sequencer::take_overrun_stats;
 
 #[entry]
 fn main() -> ! {
@@ -140,6 +142,18 @@ fn main() -> ! {
             let dirty = take_dirty();
             let mut dirty_steps: u16 = 0;
             let mut dirty_labels = false;
+
+            #[cfg(feature = "perf")]
+            {
+                let (missed_segments, max_overrun_us) = take_overrun_stats();
+                if missed_segments != 0 || max_overrun_us != 0 {
+                    rtt_target::rprintln!(
+                        "clock overrun: missed_segments={} max_overrun_us={}",
+                        missed_segments,
+                        max_overrun_us
+                    );
+                }
+            }
 
             if dirty & DIRTY_RT_CACHE != 0 {
                 rebuild_rt_cache(&sequencer_state);


### PR DESCRIPTION
Switch from 1kHz update-interrupt with atomic accumulator to TIM3 CC1 output-compare at 1MHz. This eliminates per-tick atomic load overhead and improves step timing resolution from 1ms to 1us.